### PR TITLE
Optional params

### DIFF
--- a/src/devices.js
+++ b/src/devices.js
@@ -16,6 +16,11 @@ define(["helpers"], function(helpers) {
     //
     // https://m2x.att.com/developer/documentation/v2/device#List-Search-Public-Devices-Catalog
     Devices.prototype.catalog = function(params, callback, errorCallback) {
+        if (typeof params === "function") {
+            callback = params;
+            errorCallback = callback;
+            params = {};
+        }
         return this.client.get("/devices/catalog", { qs: params || {} }, callback, errorCallback);
     };
 

--- a/src/distributions.js
+++ b/src/distributions.js
@@ -10,6 +10,11 @@ define(["helpers"], function(helpers) {
     //
     // https://m2x.att.com/developer/documentation/v2/distribution#List-Distributions
     Distributions.prototype.list = function(params, callback, errorCallback) {
+        if (typeof params === "function") {
+            callback = params;
+            errorCallback = callback;
+            params = {};
+        }
         return this.client.get("/distributions", { qs: params || {} }, callback, errorCallback);
     };
 


### PR DESCRIPTION
Make `params` an optional argument on `Devices.catalog` and `Distributions.list`.