### PR TITLE
Add Support for Device/Distribution/Collection Metadata Endpoints

### DIFF
--- a/examples/example.js
+++ b/examples/example.js
@@ -5,6 +5,7 @@
         this.$apiKey = $("input[name=api-key]");
         this.$deviceID = $("input[name=device-id]");
         this.$deviceView = $("#device-view");
+        this.$updateMetadata = $("#update-metadata-field");
         this.$streamPush = $("#stream-push");
         this.$streamView = $("#stream-view");
 
@@ -71,6 +72,25 @@
                 $.proxy(this, "onReceiveDeviceDetails"),
                 $.proxy(this, "handleError")
             );
+        }, this));
+
+        // Handler for updating device metadata field
+        this.$updateMetadata.on("click", "button", $.proxy(function() {
+            var fieldName = $("input[name=field-name]", this.$updateMetadata).val();
+            var fieldValue = $("input[name=field-value]", this.$updateMetadata).val();
+
+            if (! fieldName) {
+                alert("You must type an field name first.");
+            } else if (! fieldValue) {
+                alert("You must type a field value to be updated.");
+            } else {
+                this.setLoading(true);
+
+                this.m2x.devices.updateMetadataField(this.deviceID, fieldName, fieldValue,
+                    $.proxy(function() { this.setLoading(false); }, this),
+                    $.proxy(this, "handleError")
+                );
+            }
         }, this));
 
         // Handler for pushing values to a data stream

--- a/examples/index.html
+++ b/examples/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <link href="styles.css" type="text/css" rel="stylesheet">
-    <script src="../dist/m2x-2.0.4.js"></script>
+    <script src="../dist/m2x-3.0.1.js"></script>
 
     <!-- Keep in mind that the M2X Client does *not* require jQuery to work,
          but for the purpose of keeping things simple we're using it in this example -->
@@ -21,6 +21,22 @@
       <legend>Get device information</legend>
       <pre><code></code></pre>
       <button>Get</button>
+    </fieldset>
+
+    <fieldset id="update-metadata-field">
+      <legend>Update device metadata field</legend>
+
+      <label>Field name:</label>
+      <input type="text" name="field-name">
+      <em>Field names must begin with a lowercase letter, may contain only lowercase letters, numbers, and underscores, and may be up to 250 characters long.</em>
+
+
+      <label>Field value:</label>
+      <input type="text" name="field-value">
+      <em>Field values may be any string up to 5,000 characters.</em>
+
+      <br />
+      <button>Update Metadata</button>
     </fieldset>
 
     <fieldset id="stream-push">

--- a/src/collections.js
+++ b/src/collections.js
@@ -2,8 +2,9 @@ define(["helpers"], function(helpers) {
   // Wrapper for AT&T M2X Collections API
   //
   // https://m2x.att.com/developer/documentation/v2/collections
-    var Collections = function(client) {
+    var Collections = function(client, metadata) {
         this.client = client;
+        this.metadata = metadata;
     };
 
   // Retrieve the list of collections accessible by the authenticated API key that
@@ -70,6 +71,34 @@ define(["helpers"], function(helpers) {
     // https://m2x.att.com/developer/documentation/v2/collections#Delete-Collection
     Collections.prototype.deleteCollection = function(id, callback, errorCallback) {
         return this.client.del(helpers.url("/collections/{0}", id), callback, errorCallback);
+    };
+
+    // Read collection metadata
+    //
+    // https://m2x.att.com/developer/documentation/v2/collections#Read-Device-Metadata
+    Collections.prototype.readMetadata = function(id, callback, errorCallback) {
+        this.metadata.read("collections", id, callback, errorCallback);
+    };
+
+    // Update collection metadata
+    //
+    // https://m2x.att.com/developer/documentation/v2/collections#Update-Device-Metadata
+    Collections.prototype.updateMetadata = function(id, params, callback, errorCallback) {
+        this.metadata.update("collections", id, params, callback, errorCallback);
+    };
+
+    // Read collection metadata field
+    //
+    // https://m2x.att.com/developer/documentation/v2/collections#Read-Device-Metadata-Field
+    Collections.prototype.readMetadataField = function(id, field, callback, errorCallback) {
+        this.metadata.readField("collections", id, field, callback, errorCallback);
+    };
+
+    // Update collection metadata field
+    //
+    // https://m2x.att.com/developer/documentation/v2/collections#Update-Device-Metadata-Field
+    Collections.prototype.updateMetadataField = function(id, field, value, callback, errorCallback) {
+        this.metadata.updateField("collections", id, field, value, callback, errorCallback);
     };
 
     return Collections;

--- a/src/devices.js
+++ b/src/devices.js
@@ -1,10 +1,11 @@
 define(["helpers"], function(helpers) {
-  // Wrapper for AT&T M2X Device API
-  //
-  // https://m2x.att.com/developer/documentation/device
-    var Devices = function(client, keysAPI) {
+    // Wrapper for AT&T M2X Device API
+    //
+    // https://m2x.att.com/developer/documentation/device
+    var Devices = function(client, keysAPI, metadata) {
         this.client = client;
         this.keysAPI = keysAPI;
+        this.metadata = metadata;
     };
 
     // List/search the catalog of public devices
@@ -351,6 +352,34 @@ define(["helpers"], function(helpers) {
     // Updates an API key properties
     Devices.prototype.updateKey = function(id, key, params, callback, errorCallback) {
         this.keysAPI.update(key, helpers.extend(params, { device: id }), callback, errorCallback);
+    };
+
+    // Read device metadata
+    //
+    // https://m2x.att.com/developer/documentation/v2/device#Read-Device-Metadata
+    Devices.prototype.readMetadata = function(id, callback, errorCallback) {
+        this.metadata.read("devices", id, callback, errorCallback);
+    };
+
+    // Update device metadata
+    //
+    // https://m2x.att.com/developer/documentation/v2/device#Update-Device-Metadata
+    Devices.prototype.updateMetadata = function(id, params, callback, errorCallback) {
+        this.metadata.update("devices", id, params, callback, errorCallback);
+    };
+
+    // Read device metadata field
+    //
+    // https://m2x.att.com/developer/documentation/v2/device#Read-Device-Metadata-Field
+    Devices.prototype.readMetadataField = function(id, field, callback, errorCallback) {
+        this.metadata.readField("devices", id, field, callback, errorCallback);
+    };
+
+    // Update device metadata field
+    //
+    // https://m2x.att.com/developer/documentation/v2/device#Update-Device-Metadata-Field
+    Devices.prototype.updateMetadataField = function(id, field, value, callback, errorCallback) {
+        this.metadata.updateField("devices", id, field, value, callback, errorCallback);
     };
 
     return Devices;

--- a/src/distributions.js
+++ b/src/distributions.js
@@ -2,8 +2,9 @@ define(["helpers"], function(helpers) {
     // Wrapper for AT&T M2X Distribution API
     //
     // https://m2x.att.com/developer/documentation/distribution
-    var Distributions = function(client) {
+    var Distributions = function(client, metadata) {
         this.client = client;
+        this.metadata = metadata;
     };
 
     // Retrieve a list of device distributions
@@ -112,6 +113,34 @@ define(["helpers"], function(helpers) {
             helpers.url("/distributions/{0}/streams/{1}", id, name),
             callback, errorCallback
         );
+    };
+
+    // Read distribution metadata
+    //
+    // https://m2x.att.com/developer/documentation/v2/distribution#Read-Device-Metadata
+    Distributions.prototype.readMetadata = function(id, callback, errorCallback) {
+        this.metadata.read("distributions", id, callback, errorCallback);
+    };
+
+    // Update distribution metadata
+    //
+    // https://m2x.att.com/developer/documentation/v2/distribution#Update-Device-Metadata
+    Distributions.prototype.updateMetadata = function(id, params, callback, errorCallback) {
+        this.metadata.update("distributions", id, params, callback, errorCallback);
+    };
+
+    // Read distribution metadata field
+    //
+    // https://m2x.att.com/developer/documentation/v2/distribution#Read-Device-Metadata-Field
+    Distributions.prototype.readMetadataField = function(id, field, callback, errorCallback) {
+        this.metadata.readField("distributions", id, field, callback, errorCallback);
+    };
+
+    // Update distribution metadata field
+    //
+    // https://m2x.att.com/developer/documentation/v2/distribution#Update-Device-Metadata-Field
+    Distributions.prototype.updateMetadataField = function(id, field, value, callback, errorCallback) {
+        this.metadata.updateField("distributions", id, field, value, callback, errorCallback);
     };
 
     return Distributions;

--- a/src/m2x.js
+++ b/src/m2x.js
@@ -1,14 +1,15 @@
-define(["charts", "client", "collections", "devices", "distributions", "jobs", "keys"],
-function(Charts, Client, Collections, Devices, Distributions, Jobs, Keys) {
+define(["charts", "client", "collections", "devices", "distributions", "jobs", "keys", "metadata"],
+function(Charts, Client, Collections, Devices, Distributions, Jobs, Keys, Metadata) {
     var M2X = function(apiKey, apiBase) {
         this.client = new Client(apiKey, apiBase);
 
         this.charts = new Charts(this.client);
-        this.collections = new Collections(this.client, this.keys);
-        this.devices = new Devices(this.client, this.keys);
-        this.distributions = new Distributions(this.client);
+        this.collections = new Collections(this.client, this.keys, this.metadata);
+        this.devices = new Devices(this.client, this.keys, this.metadata);
+        this.distributions = new Distributions(this.client, this.metadata);
         this.jobs = new Jobs(this.client);
         this.keys = new Keys(this.client);
+        this.metadata = new Metadata(this.client);
     };
 
     M2X.prototype.status = function(callback, errorCallback) {

--- a/src/metadata.js
+++ b/src/metadata.js
@@ -1,0 +1,50 @@
+define(["helpers"], function(helpers) {
+    // Generic Metadata methods for M2X resources
+    var Metadata = function(client) {
+        this.client = client;
+    };
+
+  // Read resource's metadata
+  //
+  // https://m2x.att.com/developer/documentation/v2/device#Read-Device-Metadata
+  // https://m2x.att.com/developer/documentation/v2/distribution#Read-Distribution-Metadata
+  // https://m2x.att.com/developer/documentation/v2/collections#Read-Collection-Metadata
+    Metadata.prototype.read = function(resource, id, callback, errorCallback) {
+        return this.client.get(helpers.url("/{0}/{1}/metadata", resource, id), callback, errorCallback);
+    };
+
+    // Update resource's metadata
+    //
+    // https://m2x.att.com/developer/documentation/v2/device#Update-Device-Metadata
+    // https://m2x.att.com/developer/documentation/v2/distribution#Update-Distribution-Metadata
+    // https://m2x.att.com/developer/documentation/v2/collections#Update-Collection-Metadata
+    Metadata.prototype.update = function(resource, id, params, callback, errorCallback) {
+        return this.client.put(helpers.url("/{0}/{1}/metadata", resource, id), {
+            headers: { "Content-Type": "application/json" },
+            params: params
+        }, callback, errorCallback);
+    };
+
+    // Read resource's metadata field
+    //
+    // https://m2x.att.com/developer/documentation/v2/device#Read-Device-Metadata-Field
+    // https://m2x.att.com/developer/documentation/v2/distribution#Read-Distribution-Metadata-Field
+    // https://m2x.att.com/developer/documentation/v2/collections#Read-Collection-Metadata-Field
+    Metadata.prototype.readField = function(resource, id, field, callback, errorCallback) {
+        return this.client.get(helpers.url("/{0}/{1}/metadata/{2}", resource, id, field), callback, errorCallback);
+    };
+
+    // Update resource's metadata field
+    //
+    // https://m2x.att.com/developer/documentation/v2/device#Update-Device-Metadata-Field
+    // https://m2x.att.com/developer/documentation/v2/distribution#Update-Distribution-Metadata-Field
+    // https://m2x.att.com/developer/documentation/v2/collections#Update-Collection-Metadata-Field
+    Metadata.prototype.updateField = function(resource, id, field, fieldValue, callback, errorCallback) {
+        return this.client.put(helpers.url("/{0}/{1}/metadata/{2}", resource, id, field), {
+            headers: { "Content-Type": "application/json" },
+            params: { value: fieldValue }
+        }, callback, errorCallback);
+    };
+
+    return Metadata;
+});

--- a/src/metadata.js
+++ b/src/metadata.js
@@ -4,11 +4,11 @@ define(["helpers"], function(helpers) {
         this.client = client;
     };
 
-  // Read resource's metadata
-  //
-  // https://m2x.att.com/developer/documentation/v2/device#Read-Device-Metadata
-  // https://m2x.att.com/developer/documentation/v2/distribution#Read-Distribution-Metadata
-  // https://m2x.att.com/developer/documentation/v2/collections#Read-Collection-Metadata
+      // Read resource's metadata
+      //
+      // https://m2x.att.com/developer/documentation/v2/device#Read-Device-Metadata
+      // https://m2x.att.com/developer/documentation/v2/distribution#Read-Distribution-Metadata
+      // https://m2x.att.com/developer/documentation/v2/collections#Read-Collection-Metadata
     Metadata.prototype.read = function(resource, id, callback, errorCallback) {
         return this.client.get(helpers.url("/{0}/{1}/metadata", resource, id), callback, errorCallback);
     };


### PR DESCRIPTION
See [Ruby library implementation](https://github.com/attm2x/m2x-ruby/commit/044b282afd614e87e68b7516353d65cbe3c79ab0) for reference.

Add support for the following endpoints:

Device Metadata:
* https://m2x.att.com/developer/documentation/v2/device#Read-Device-Metadata
* https://m2x.att.com/developer/documentation/v2/device#Update-Device-Metadata
* https://m2x.att.com/developer/documentation/v2/device#Read-Device-Metadata-Field
* https://m2x.att.com/developer/documentation/v2/device#Update-Device-Metadata-Field

Distribution Metadata:
* https://m2x.att.com/developer/documentation/v2/distribution#Read-Distribution-Metadata
* https://m2x.att.com/developer/documentation/v2/distribution#Update-Distribution-Metadata
* https://m2x.att.com/developer/documentation/v2/distribution#Read-Distribution-Metadata-Field
* https://m2x.att.com/developer/documentation/v2/distribution#Update-Distribution-Metadata-Field

Collection Metadata:
* https://m2x.att.com/developer/documentation/v2/collections#Read-Collection-Metadata
* https://m2x.att.com/developer/documentation/v2/collections#Update-Collection-Metadata
* https://m2x.att.com/developer/documentation/v2/collections#Read-Collection-Metadata-Field
* https://m2x.att.com/developer/documentation/v2/collections#Update-Collection-Metadata-Field